### PR TITLE
feat: middleware uses local resources when present

### DIFF
--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -3,6 +3,10 @@ const { getReverseAliases, getAliases, getPackages } = require("./generalUtils")
 const { getExternalFile, getExternalModuleData } = require("./babelUtils");
 const normalizer = require("@ui5/project").normalizer;
 
+const {
+    createHelper
+} = require("./util");
+
 /**
  * Custom middleware to enable the usage of UI5 Web Components projects in UI5
  *
@@ -26,6 +30,9 @@ module.exports = async function serveWebComponents({
     middlewareUtil
 }) {
     // const verbose = options?.configuration?.verbose;
+
+    const helper = createHelper(resources.dependencies);
+
     let project; // for the OpenUI5 monorepo use case the try will fail and project will remain "undefined"
     try {
         project = await normalizer.generateProjectTree(); // needed for the project's own configuration (unless it's the monorepo use case)
@@ -35,16 +42,24 @@ module.exports = async function serveWebComponents({
     const aliases = getAliases(packages); // used to convert module paths to resource paths, understandable by the UI5 loader
 
     return async (req, res, next) => {
-        // Determine if the required resource is an external file (not in the src/ directory, but rather part of a shimmed third-party web components project)
-        const externalFile = await getExternalFile(req.path, reverseAliases);
+        // Check if the resource is in the file system
+        const resource = await helper.byPath(req.path);
 
-        // If yes, find it in node_modules/, transpile it, and serve it.
-        if (externalFile) {
-            const { code, mime } = await getExternalModuleData(externalFile, aliases);
-            res.setHeader("Content-Type", mime);
-            res.send(code);
-            res.end();
-        // If no, then this is a true src/ file and just serve it normally
+        // If not found, then it is either an external file (and should be read from node_modules/ and transpiled) or just a bad request
+        if (!resource) {
+            // Determine if the required resource is an external file (not in the src/ directory, but rather part of a shimmed third-party web components project)
+            const externalFile = await getExternalFile(req.path, reverseAliases);
+
+            // If yes, find it in node_modules/, transpile it, and serve it.
+            if (externalFile) {
+                const { code, mime } = await getExternalModuleData(externalFile, aliases);
+                res.setHeader("Content-Type", mime);
+                res.send(code);
+                res.end();
+                // If no, then this is a true src/ file and just serve it normally
+            } else {
+                next();
+            }
         } else {
             next();
         }


### PR DESCRIPTION
Short version:
This changes the way `middleware` handles `thirdparty/` resource requests.

Long version:
Every resource that matches the `reverseAliases` was read from `node_modules/` and transpiled. Basically, this means that any request for the web components libraries that has `thirdparty/` is assumed to be found in `node_modules/` as a dependency. While this is true for OpenUI5 itself (it has all `@ui5/webcomponents*` packages as `devDependency`), this is not the case for third-party libraries: for these, the OpenUI5 monorepo is not a dependency (only individual OpenUI5 libraries are), therefore third-party libraries do not have `@ui5/webcomponents*` as any kind of dependency. As a result, middleware requests to `@ui5/webcomponents-icons` and similar failed. This change fixes that by allowing the middleware to look for such files in the filesystem first. The third-party libraries will have `@openui5/sap.ui.webc.common` as a dependency and will be able to find the files in its `src-gen` directory as a result.
