### PR TITLE
chore: release 0.1.7

### DIFF
--- a/lib/generate/builders/ControlFileBuilder.js
+++ b/lib/generate/builders/ControlFileBuilder.js
@@ -42,6 +42,7 @@ class ControlFileBuilder extends BuilderBase {
         // replace links
         description = description.replace(/<ui5-link.*?href="(.*?)".*?>(.*?)<\/ui5-link>/g, "{@link $1 $2}");
         description = description.replace(/https:\/\/openui5.hana.ondemand.com\/test-resources\//g, "demo:");
+        description = description.replace(/https:\/\/sdk.openui5.org\/test-resources\//g, "demo:");
         description = description.replace(/sapui5.hana.ondemand.com/g, "ui5.sap.com");
 
         // replace accessibleNameRef with ariaLabel (association)

--- a/lib/generate/builders/ControlModel.js
+++ b/lib/generate/builders/ControlModel.js
@@ -128,13 +128,14 @@ class ControlModel {
         const properties = (this.control.properties || []).filter(prop => prop.visibility === "public" && !prop.readonly && !propertiesExcludeList.includes(prop.name) && !this.isAssociationProperty(prop)); //  && prop.type !== "undefined"
         properties.forEach(prop => {
             const type = this.buildPropertyType(prop);
-            if (type.startsWith("sap.ui.") && prop.defaultValue) {
+            if (type.includes(".") && prop.defaultValue) {
                 this.neededEnums.add(type);
             }
 
             let defaultValue = prop.defaultValue;
-            if (type.startsWith("sap.ui") && prop.defaultValue) {
-                defaultValue = `${prop.type}.${prop.defaultValue.replace(/"/g, "")}`
+            if (type.includes(".") && prop.defaultValue) {
+                const typeBaseName = prop.type.split(".").pop();
+                defaultValue = `${typeBaseName}.${prop.defaultValue.replace(/"/g, "")}`
             }
             if (type === "object" && !defaultValue) {
                 defaultValue = `{}`;

--- a/lib/generate/utils/getAllEntities.js
+++ b/lib/generate/utils/getAllEntities.js
@@ -1,6 +1,6 @@
 const getComponentByName = (name, entries) => {
     return entries.find(element => {
-        return element.basename === name;
+        return element.name === name || element.basename === name;
     })
 };
 

--- a/lib/generate/utils/normalizeType.js
+++ b/lib/generate/utils/normalizeType.js
@@ -3,35 +3,31 @@ const normalizeType = (type) => {
         return "string";
     }
 
-    if (type === "Integer") {
-        return "int";
-    }
-
     if (type === "Boolean") {
         return "boolean";
-    }
-
-    if (type === "Float") {
-        return "float";
     }
 
     if (type === "Object" || type === "File") {
         return "object";
     }
 
-    if (type === "ValueState") {
+    if (type === "sap.ui.webc.base.Integer" || type === "Integer") {
+        return "int";
+    }
+
+    if (type === "sap.ui.webc.base.Float" || type === "Float") {
+        return "float";
+    }
+
+    if (type === "sap.ui.webc.base.ValueState" || type === "ValueState") {
         return "sap.ui.core.ValueState";
     }
 
-    if (type === "CSSSize") {
-        return "sap.ui.core.CSSSize";
-    }
-
-    if (type === "CSSColor") {
+    if (type === "sap.ui.webc.base.CSSColor" || type === "CSSColor") {
         return "sap.ui.core.CSSColor";
     }
 
-    if (type === "CalendarType") {
+    if (type === "sap.ui.webc.base.CalendarType" || type === "CalendarType") {
         return "sap.ui.core.CalendarType";
     }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ui5/tooling-webc",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "UI5 Tooling Extensions to include UI5 Web Components projects into OpenUI5/SAPUI5",
   "author": "SAP SE",
   "license": "Apache-2.0",


### PR DESCRIPTION
This version:
 - supports types with full namespaces in JSDoc (f.e. `sap.ui.webc.main.types.AvatarShape` instead of `AvatarShape`)
 - converts some more links to `demo:` for OpenUI5