### PR TITLE
fix: instance generator no longer creates bad JS

### DIFF
--- a/lib/generate/builders/ControlInstanceBuilder.js
+++ b/lib/generate/builders/ControlInstanceBuilder.js
@@ -95,13 +95,21 @@ class ControlInstanceBuilder extends BuilderBase {
 	}
 
 	multipleAggregation(agg) {
+		const children = this.generateChildrenForAggregation(agg, 3);
+		if (!children) {
+			return "";
+		}
 		return `${agg.name}: [
-			${this.generateChildrenForAggregation(agg, 3)}
+			${children}
 		],`;
 	}
 
 	singleAggregation(agg) {
-		return `${agg.name}: ${this.generateChildrenForAggregation(agg, 1)},`;
+		const child = this.generateChildrenForAggregation(agg, 1);
+		if (!child) {
+			return "";
+		}
+		return `${agg.name}: ${child},`;
 	}
 
 	generateChildrenForAggregation(agg, howMany = 1) {
@@ -136,7 +144,7 @@ class ControlInstanceBuilder extends BuilderBase {
 			});
 		}
 
-		return arr.join(",\n");
+		return arr.filter(str => !!str).join(",\n");
 	}
 
 	get events() {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ui5/tooling-webc",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "description": "UI5 Tooling Extensions to include UI5 Web Components projects into OpenUI5/SAPUI5",
   "author": "SAP SE",
   "license": "Apache-2.0",


### PR DESCRIPTION
For too deep levels of nesting, single aggregations were incorrectly built.